### PR TITLE
fix: header logo href from trying to take user to root of repository

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -68,7 +68,7 @@ export default function Header() {
     return (
         <header ref={headerRef} className={headerClasses}>
             <div className="container max-w-full w-full flex justify-between md:justify-around items-center px-3 md:px-0">
-                <a href="/" className="headerLogo hover:opacity-50 transition duration-300">
+                <a href="./" className="headerLogo hover:opacity-50 transition duration-300">
                     <ChicagoSkyline />
                 </a>
                 <div className="hamburger-menu block md:hidden">


### PR DESCRIPTION
# Summary
Previously the href path that the `Header` logo contained was directing users to the root of the directory. This change fixes that bug

## Changes
-  Update the href for the `Header` logo anchor link